### PR TITLE
Fix icon buttons collapsing when screen width is less than 416px

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,10 +106,10 @@
                             <h2>Corvus OS<br><span id="js-rotating">FEATURES, SPEEDY, SMOOTHNESS</span></h2>
                             <p class="p-large">Corvus OS is based on AOSP, with all the useful features required. Our objective is stability while being feature-rich at the same time. We won't believe that Corvus is better ROM than others, but we will always try to give you the best.</p>
                             <div class="d-flex justify-content-center">
-                            <a class="btn-solid-lg page-scroll" href="download.html"><i class="fas fa-angle-double-down"></i> Download</a>
-                            <a class="btn-solid-lg popup-with-move-anim" href="#details-lightbox-1"><i class="fas fa-bullhorn"></i>What's new</a>
+                            <a class="btn-solid-lg page-scroll text-nowrap" href="download.html"><i class="fas fa-angle-double-down"></i> Download</a>
+                            <a class="btn-solid-lg popup-with-move-anim text-nowrap" href="#details-lightbox-1"><i class="fas fa-bullhorn"></i>What's new</a>
                             </div>
-                            <div class="d-flex justify-content-center">
+                            <div class="d-flex justify-content-center text-nowrap">
                                 <a class="btn-solid-lg" href="maintainer.html"><i class="fas fa-address-card"></i>Apply for Maintainership</a>
                             </div>
                         </div>


### PR DESCRIPTION
**Issue**
The main buttons of home page get collapsed with icons in most mobile devices.
Here is a example on Poco X3 NFC: 
https://i.imgur.com/BBoAvhu.jpg

**Pull Request**
It's just a small fix for it to prevent the icons from collapsing in any screen size.
After the fix: 
https://i.imgur.com/6F2B4eT.jpg